### PR TITLE
fix(exports): Update main and types in package.json to point to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "aws-dynasync",
   "description": "Create an AWS AppSync GraphQL Api and a DynamoDB datasource with a single command. Automate the building and provisioning of a GraphQL API using a single config file with AWS AppSync and Amazon DynamoDb to store the data. The entire process is controlled by a single config file that defines the data tables and GraphQl types to be used. Then using the AWS CDK all of the tables are created, all of the queries and mutations are generated, and all of the data sources connected to have a fully functioning API.",
-  "main": "lib/index.js",
+  "main": "lib/export.js",
+  "types": "lib/types/export.d.ts",
   "version": "1.1.6",
   "scripts": {
     "test": "jest --ci --reporters=default --coverage \".*\\..*\"",
@@ -25,23 +26,23 @@
   "author": "sguggenh@amazon.com",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^29.1.1",
+    "@aws-cdk/integ-runner": "^2.88.0-alpha.0",
+    "@aws-cdk/integ-tests-alpha": "^2.88.0-alpha.0",
+    "@types/jest": "^29.5.3",
     "@types/node": "^17.0.35",
-    "jest": "^29.1.2",
-    "ts-jest": "^29.0.3",
-    "typescript": "^4.8.4",
-    "@aws-cdk/integ-runner": "^2.77.0-alpha.0",
-    "@aws-cdk/integ-tests-alpha": "^2.77.0-alpha.0",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
     "typedoc": "^0.24.8",
     "typedoc-github-wiki-theme": "^1.1.0",
-    "typedoc-plugin-markdown": "^3.15.3"
+    "typedoc-plugin-markdown": "^3.15.4",
+    "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@aws-cdk/aws-appsync-alpha": "2.52.1-alpha.0",
+    "@aws-cdk/aws-appsync-alpha": "^2.52.1-alpha.0",
     "@types/node": "*",
-    "aws-cdk": "^2.59.0",
-    "aws-cdk-lib": "^2.59.0",
-    "constructs": "^10.0.94",
+    "aws-cdk": "^2.88.0",
+    "aws-cdk-lib": "^2.88.0",
+    "constructs": "^10.2.69",
     "typescript": "*"
   },
   "overrides": {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,8 +3,8 @@ import { AppSyncSchema } from './schema';
 import { getName, validateTable } from '../util';
 import { DbTable } from '../db/table';
 import { SchemaTable, GraphQlTypeList, AppsyncApiProps, DynamoTableProps } from '../types';
-import { 
-    GraphqlApi, 
+import {
+    GraphqlApi,
     ISchema,
     DynamoDbDataSource,
     AuthorizationConfig
@@ -23,10 +23,10 @@ export class AppSyncStack {
     schema: AppSyncSchema
     tables: DbTable[] = []
     data: DynamoDbDataSource[] = [];
-    
+
     constructor(
-        public scope: Construct, 
-        protected id: string, 
+        public scope: Construct,
+        protected id: string,
         private props: AppSyncStackProps
     ) {
         this.schema = new AppSyncSchema();

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,2 +1,2 @@
-export { Dynasync } from '.';
-export * as types from './types';
+export { Dynasync } from ".";
+export * as types from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { readFileSync, existsSync  } from 'fs';
 import { extname, join } from "path";
 import { DbTable } from "./db/table";
 import { AppSyncStack } from "./api";
-import { AuthorizationConfig, AuthorizationMode, AuthorizationType, UserPoolDefaultAction } from "aws-cdk-lib/aws-appsync";
+import { AuthorizationConfig, AuthorizationMode, AuthorizationType, GraphqlApi, UserPoolDefaultAction } from "aws-cdk-lib/aws-appsync";
 import { UserPool } from "aws-cdk-lib/aws-cognito";
 
 export class Dynasync extends Resource {
@@ -20,9 +20,16 @@ export class Dynasync extends Resource {
         return new Dynasync(scope,id,props);
     }
 
+    /**
+     * {@link GraphqlApi} created by Dynasync
+     */
+    get api(): GraphqlApi {
+        return this.appsync.api;
+    }
+
     constructor(
-        protected scope: Construct, 
-        protected id: string, 
+        protected scope: Construct,
+        protected id: string,
         protected $props: DynasyncProps = {
             tables:[],
             types: {}
@@ -46,10 +53,10 @@ export class Dynasync extends Resource {
             defaultAuthorization = this.getUserPoolAuthMode(properties);
         } else {
             defaultAuthorization = (properties.auth || []).shift();
-        } 
-        let additionalAuthorizationModes: AuthorizationMode[] | undefined = properties.auth?.length ? 
+        }
+        let additionalAuthorizationModes: AuthorizationMode[] | undefined = properties.auth?.length ?
             properties.auth : undefined;
-        const config = {
+        const config: AuthorizationConfig = {
             defaultAuthorization,
             additionalAuthorizationModes
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import { SchemaLocalIndex } from "./key/local"
 import { Duration, RemovalPolicy, ResourceProps } from "aws-cdk-lib"
 import { IUserPool } from "aws-cdk-lib/aws-cognito"
 import { DbTable } from "./db/table"
-import { Directive, IField, IIntermediateType, InterfaceType } from "@aws-cdk/aws-appsync-alpha"
+import { Directive, IField, IIntermediateType, InterfaceType } from "@aws-cdk/aws-appsync-alpha";
 import { AuthorizationMode, DomainOptions, LogConfig, Resolver } from "aws-cdk-lib/aws-appsync"
 import { IKey } from "aws-cdk-lib/aws-kms"
 import { IStream } from "aws-cdk-lib/aws-kinesis"
@@ -105,25 +105,25 @@ export interface DynamoTableProps {
 export type DynamoAttribute = "B" | "S" | "N";
 
 export interface DynamoAttributes {
-    [ name: string ]: DynamoAttribute 
+    [ name: string ]: DynamoAttribute
 }
 
 export type SchemaObject = Record<string, string>
 
 
-export type GraphType = 'id' | 'string' | 'int' | 'float' | 'boolean' | 
-'awsDate' | 'awsTime' | 'awsDateTime' | 'awsTimestamp' | 'awsEmail' | 
+export type GraphType = 'id' | 'string' | 'int' | 'float' | 'boolean' |
+'awsDate' | 'awsTime' | 'awsDateTime' | 'awsTimestamp' | 'awsEmail' |
 'awsJson' | 'awsUrl' | 'awsPhone' | 'awsIpAddress' | 'intermediate'
 
 export interface IntermediateTypes {
     [name:string]: IIntermediateType
-}  
+}
 
 export type IntermediateType = 'type' | 'input' | 'interface' | 'union' | 'enum';
 
 export interface SchemaFields {
     [name:string]: IField
-} 
+}
 
 export interface IntermediateTypeBase {
     directives?: Directive[]


### PR DESCRIPTION
The main and types fields were not configured correctly to point to exports. This caused projects that installed the library to not correctly find the types and interfered with Intellisense